### PR TITLE
Omit oneTimeAddress when externalWalletId is provided

### DIFF
--- a/src/bridge/ethers-bridge.ts
+++ b/src/bridge/ethers-bridge.ts
@@ -19,7 +19,7 @@ export class EthersBridge extends BaseBridge {
             destination: {
                 type: this.params.externalWalletId ? PeerType.EXTERNAL_WALLET : PeerType.ONE_TIME_ADDRESS,
                 id: this.params.externalWalletId,
-                oneTimeAddress: {
+                oneTimeAddress: this.params.externalWalletId ? undefined : {
                     address: <string>transaction.to
                 }
             },

--- a/src/bridge/web3-bridge.ts
+++ b/src/bridge/web3-bridge.ts
@@ -78,7 +78,7 @@ export class Web3Bridge extends BaseBridge {
             destination: {
                 type: this.params.externalWalletId ? PeerType.EXTERNAL_WALLET : PeerType.ONE_TIME_ADDRESS,
                 id: this.params.externalWalletId,
-                oneTimeAddress: {
+                oneTimeAddress: this.params.externalWalletId ? undefined : {
                     address: transaction.to
                 }
             },


### PR DESCRIPTION
## Pull Request Description

We have encountered an issue when trying to send transactions to contract whitelisted as External Wallet.
This issue was fixed by omitting `oneTimeAddress` in transaction request.
An example of this fix is provided in this PR

Fixes our internal issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore / Documentation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Tested by creating a new transaction and it passing the policy successfully

- [x] Locally tested against Fireblocks API

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have added corresponding labels to the PR
