### PR TITLE
removed notes from buildTransaction call for NFT custom-token

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/fireblocks/fireblocks-defi-sdk.git"
+    "url": "https://github.com/GNSMFCORP/fireblocks-defi-sdk.git"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/src/interfaces/bridge-params.ts
+++ b/src/interfaces/bridge-params.ts
@@ -1,5 +1,6 @@
 import { Chain } from "./chain";
 import {FireblocksSDK} from "fireblocks-sdk";
+import { Signer, providers } from "ethers";
 
 export interface BridgeParams {
     fireblocksApiClient: FireblocksSDK;
@@ -7,4 +8,5 @@ export interface BridgeParams {
     externalWalletId?: string;
     chain?: Chain;
     contractAddress?: string;
+    signerOrProvider?: Signer | providers.Provider;
 }

--- a/src/nft/base-token.ts
+++ b/src/nft/base-token.ts
@@ -29,7 +29,7 @@ export class BaseToken {
         this.contractABI = contractABI
         this.contract = new ethers.Contract(this.bridgeParams.contractAddress,
             JSON.stringify(this.contractABI),
-            ethers.getDefaultProvider(this.bridgeParams.chain));
+            this.bridgeParams.signerOrProvider ?? ethers.getDefaultProvider(this.bridgeParams.chain));
         this._allFunctions = this.contract.functions;
     }
 

--- a/src/nft/custom-token.ts
+++ b/src/nft/custom-token.ts
@@ -26,7 +26,7 @@ export class CustomToken extends BaseToken {
      * @param args - arguments for contract call (addresses should be wrapped with Web3.toChecksumAddress(address)
      */
     async callWriteFunction(abiFunctionName: string, notes: string, ...args): Promise<CreateTransactionResponse> {
-        const transactionData = await this.buildTransaction(abiFunctionName, ...args, notes);
+        const transactionData = await this.buildTransaction(abiFunctionName, ...args);
         return this.submitTransaction(transactionData, notes);
     }
 


### PR DESCRIPTION
## Pull Request Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes (link to the issue here)
- Notes was being sent to the buildTransaction call which would also include that as a parameter for the contract call resulting in a error 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore / Documentation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Locally tested against Fireblocks API

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have added corresponding labels to the PR
