### PR TITLE
Bump ethers version to fix "toBigInt" bug

### DIFF
--- a/examples/aave-example/package.json
+++ b/examples/aave-example/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "ethers": "^5.0.23",
+    "ethers": "^5.5.1",
     "fireblocks-defi-sdk": "file:../..",
     "fireblocks-sdk": "^1.5.11",
     "inquirer": "^7.3.3"


### PR DESCRIPTION
Running the example with version <5.1.0 raises an error due to BigNumber not having toBigInt method https://github.com/ethers-io/ethers.js/releases/tag/v5.1.0
