### PR TITLE
Update matic mumbai name

### DIFF
--- a/src/interfaces/chain.ts
+++ b/src/interfaces/chain.ts
@@ -6,7 +6,7 @@ export enum Chain {
     BSC = "bsc",
     BSC_TEST = "bsc_test",
     POLYGON = "matic",
-    MUMBAI = "polygon_test",
+    MUMBAI = "maticmum",
     RINKEBY = "rinkeby",
     ARBITRUM = "arbitrum",
     AVALANCHE = "avalanche",


### PR DESCRIPTION
This depends on https://github.com/ethers-io/ethers.js/pull/3935 as well to work, but matic mumbai chain name did not match ethers' name.
